### PR TITLE
Add Manifest.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,7 @@ docs/site/
 # It records a fixed state of all packages used by the project. As such, it should not be
 # committed for packages, but should be committed for applications that require a static
 # environment.
-Manifest.toml
+# Manifest.toml
 
 ## Output files
 *.jld2


### PR DESCRIPTION
I suggest we add the Manifest.toml here. It's useful to inlclude the Manifest to ensure reproducibility. This way, when we submit a run the Manifest.toml will ensure that all package version and their deps are pinned to the exact versions used.