### PR TITLE
Add ClimaOcean compat entry

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -14,6 +14,7 @@ PolygonOps = "647866c9-e3ac-4575-94e7-e3d426903924"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [compat]
+ClimaOcean = "0.6"
 CFTime = "0.1.4"
 CUDA = "5.7"
 Oceananigans = "0.96"


### PR DESCRIPTION
This is to avoid accidental update to v0.7 which will induce breaking changes to the vertical grid construction; see https://github.com/CliMA/ClimaOcean.jl/pull/565