### PR TITLE
Diagnose halo-fold free-surface substepping

### DIFF
--- a/analysis/analysis_checkpointers.jl
+++ b/analysis/analysis_checkpointers.jl
@@ -14,7 +14,7 @@ labels = [
     "No sea ice dynamics",
     "No sea ice salinity flux",
     "No sea ice thermodynamics",
-    "Coupled OSIM"
+    "Coupled OSIM with ECCO4"
 ]
 
 basepath = "/data/gpfs/projects/punim2499/taimoor/ocean-ensembles/outputs/"
@@ -52,7 +52,7 @@ for (i, (w, label)) in enumerate(zip(w_list, valid_labels))
         colorrange = (-5e-4, 5e-4),
         colormap = :balance
     )
-    scatter!(ax, [1735-1600], [1085-894], color = :red)
+    # scatter!(ax, [1735-1600], [1085-894], color = :red)
 end
 
 save(joinpath(outpath, "w_plot_debugging.png"), fig, dpi=300)

--- a/experiments/RYF_sxtdeg_serial.jl
+++ b/experiments/RYF_sxtdeg_serial.jl
@@ -44,9 +44,9 @@ output_depths = [0, -100, -500, -1000, -2000]
 
 checkpoint_interval = TimeInterval(10days)
 output_interval = AveragedTimeInterval(5days)
-callback_iteration_interval = TimeInterval(10days)
+callback_iteration_interval = 720
 default_checkpoint_prefix = "RYF_sxtdeg_checkpoint"
-default_mediaflux_archive_interval = 6days
+default_mediaflux_archive_interval = 365days
 mediaflux_archive_submission_script = joinpath(@__DIR__, "submission_scripts", "mediaflux_archive_checkpoints.sh")
 
 function gpu_memory_status(prefix="")
@@ -201,7 +201,7 @@ end
 function add_progress_callback!(simulation; callback_iteration_interval = callback_iteration_interval)
     start_wall_time = Ref(time_ns())
     wall_time = Ref(time_ns())
-    callback_interval = TimeInterval(callback_iteration_interval)
+    callback_interval = IterationInterval(callback_iteration_interval)
 
     function progress(sim)
         η = sim.model.ocean.model.free_surface.displacement
@@ -523,7 +523,7 @@ function build_simulation(arch, run_id;
     closure = (catke_closure, VerticalScalarDiffusivity(κ=1e-5, ν=1e-4))
 
     @info "Defining free surface"
-    free_surface = SplitExplicitFreeSurface(grid; substeps=100)
+    free_surface = SplitExplicitFreeSurface(grid; substeps=70)
     momentum_advection = WENOVectorInvariant()
     tracer_advection = WENO(order=7)
     sea_ice_advection = WENO(order=7, minimum_buffer_upwind_order=1)
@@ -598,6 +598,12 @@ function run_segment!(state; pickup=false, Δt=nothing, stop_time=nothing, stop_
         simulation.stop_time = stop_time
     elseif !isnothing(stop_iteration) && !isnothing(stop_time)
         error("Only one of stop_time or stop_iteration should be provided")
+    end
+    fs = SplitExplicitFreeSurface(state.simulation.model.ocean.model.grid; cfl=0.8, fixed_Δt=Δt)
+    @show substeps_rec = length(fs.substepping.averaging_weights)
+    @show substeps_actual = length(state.simulation.model.ocean.model.free_surface.substepping.averaging_weights)
+    if substeps_rec > substeps_actual
+        @warn "Actual number of substeps ($(substeps_actual)) is less than the recommended number of free surface substeps ($(substeps_rec)) for cfl=0.8."
     end
 
     @info "Running simulation" state.run_id pickup stop_time=prettytime(simulation.stop_time)

--- a/experiments/RYF_sxtdeg_serial.jl
+++ b/experiments/RYF_sxtdeg_serial.jl
@@ -42,10 +42,12 @@ const Nz = Integer(75)
 const depth = -5500.0
 output_depths = [0, -100, -500, -1000, -2000]
 
-checkpoint_interval = TimeInterval(120minutes)
-output_interval = AveragedTimeInterval(1days)
-diagnostic_surface_interval = IterationInterval(1)
-callback_iteration_interval = 10
+checkpoint_interval = TimeInterval(10days)
+output_interval = AveragedTimeInterval(5days)
+callback_iteration_interval = TimeInterval(10days)
+default_checkpoint_prefix = "RYF_sxtdeg_checkpoint"
+default_mediaflux_archive_interval = 6days
+mediaflux_archive_submission_script = joinpath(@__DIR__, "submission_scripts", "mediaflux_archive_checkpoints.sh")
 
 function gpu_memory_status(prefix="")
     if !isdefined(Main, :CUDA)
@@ -92,6 +94,9 @@ end
 function ryf_dates()
     return vcat(collect(DateTime(1991, 1, 1):Month(1):DateTime(1991, 4, 1)),
                 collect(DateTime(1990, 5, 1):Month(1):DateTime(1990, 12, 1)))
+end
+function ecco_dates()
+    return collect(DateTime(1993, 1, 1):Month(1):DateTime(1993, 12, 1))
 end
 
 function download_input_data!(dates, dataset)
@@ -196,22 +201,7 @@ end
 function add_progress_callback!(simulation; callback_iteration_interval = callback_iteration_interval)
     start_wall_time = Ref(time_ns())
     wall_time = Ref(time_ns())
-    callback_interval = IterationInterval(callback_iteration_interval)
-    target_cfl_site = (1735, 1085, 75)
-
-    ocean_model = simulation.model.ocean.model
-    grid = ocean_model.grid
-    u, v, w = ocean_model.velocities
-
-    inverse_timescale_operation =
-        KernelFunctionOperation{Center, Center, Center}(advective_inverse_timescaleᶜᶜᶜ,
-                                                        grid, u, v, w)
-
-    inverse_timescale_field = Field(inverse_timescale_operation)
-
-    longitudes = λnodes(grid, Center(), Center(), Center(); with_halos=false)
-    latitudes = φnodes(grid, Center(), Center(), Center(); with_halos=false)
-    depths = znodes(grid, Center(), Center(), Center(); with_halos=false)
+    callback_interval = TimeInterval(callback_iteration_interval)
 
     function progress(sim)
         η = sim.model.ocean.model.free_surface.displacement
@@ -219,38 +209,10 @@ function add_progress_callback!(simulation; callback_iteration_interval = callba
         T, S = sim.model.ocean.model.tracers
         iteration = Oceananigans.iteration(sim)
 
-        compute!(inverse_timescale_field)
-        maximum_inverse_timescale, cfl_index = findmax_interior_field(inverse_timescale_field)
-        i, j, k = Tuple(cfl_index)
-        ti, tj, tk = target_cfl_site
-        tni, tnj, tnk = ti - grid.Hx, tj - grid.Hy, tk - grid.Hz
-
-        inverse_timescale_u, inverse_timescale_v, inverse_timescale_w =
-            maybe_allow_scalar() do
-                advective_inverse_timescale_componentsᶜᶜᶜ(i, j, k, grid, u, v, w)
-            end
-
-        target_longitude, target_latitude, target_depth =
-            maybe_allow_scalar() do
-                (longitude_value(longitudes, tni, tnj),
-                 latitude_value(latitudes, tni, tnj),
-                 depth_value(depths, tni, tnj, tnk))
-            end
-
-        sea_ice_model = sim.model.sea_ice.model
-        sea_ice_ocean_fluxes = sim.model.interfaces.sea_ice_ocean_interface.fluxes
-        cfl_u = sim.Δt * inverse_timescale_u
-        cfl_v = sim.Δt * inverse_timescale_v
-        cfl_w = sim.Δt * inverse_timescale_w
+        # The CFL hotspot and dominant-term diagnostics were helpful for debugging,
+        # but they add an expensive full-field search and extra reductions/copies.
+        # Keep only the aggregate advective CFL in routine progress logging.
         advective_cfl = AdvectiveCFL(sim.Δt)(sim.model.ocean.model)
-        dominant_component = dominant_cfl_component(cfl_u, cfl_v, cfl_w)
-
-        cfl_longitude, cfl_latitude, cfl_depth =
-            maybe_allow_scalar() do
-                (longitude_value(longitudes, i, j),
-                 latitude_value(latitudes, i, j),
-                 depth_value(depths, i, j, k))
-            end
 
         Trange = (maximum(T), minimum(T))
         Srange = (maximum(S), minimum(S))
@@ -259,21 +221,6 @@ function add_progress_callback!(simulation; callback_iteration_interval = callba
         umax = (maximum(abs, u),
                 maximum(abs, v),
                 maximum(abs, w))
-
-        i_stencil = max(first(axes(sea_ice_ocean_fluxes.salt, 1)), ti - 3):min(last(axes(sea_ice_ocean_fluxes.salt, 1)), ti + 3)
-        j_stencil = max(first(axes(sea_ice_ocean_fluxes.salt, 2)), tj - 3):min(last(axes(sea_ice_ocean_fluxes.salt, 2)), tj + 3)
-
-        salt_flux_stencil, ice_concentration_stencil, salt_flux_xgrad_stencil, salt_flux_ygrad_stencil, ice_concentration_xgrad_stencil, ice_concentration_ygrad_stencil =
-            maybe_allow_scalar() do
-                ([sea_ice_ocean_fluxes.salt[ii, jj, 1] for jj in j_stencil, ii in i_stencil],
-                 [sea_ice_model.ice_concentration[ii, jj, 1] for jj in j_stencil, ii in i_stencil],
-                 [∂xᶠᶜᶜ(ii, jj, 1, grid, sea_ice_ocean_fluxes.salt) for jj in j_stencil, ii in i_stencil],
-                 [∂yᶜᶠᶜ(ii, jj, 1, grid, sea_ice_ocean_fluxes.salt) for jj in j_stencil, ii in i_stencil],
-                 [∂xᶠᶜᶜ(ii, jj, 1, grid, sea_ice_model.ice_concentration) for jj in j_stencil, ii in i_stencil],
-                 [∂yᶜᶠᶜ(ii, jj, 1, grid, sea_ice_model.ice_concentration) for jj in j_stencil, ii in i_stencil])
-            end
-
-        fmt_stencil(A) = join(["[" * join([@sprintf("%.2e", A[row, col]) for col in axes(A, 2)], ", ") * "]" for row in axes(A, 1)], " ")
 
         current_wall_time = time_ns()
         step_time = 1e-9 * (current_wall_time - wall_time[])
@@ -287,14 +234,60 @@ function add_progress_callback!(simulation; callback_iteration_interval = callba
         msg6 = @sprintf("wall time: %s\n", prettytime(step_time))
         msg7 = @sprintf("elapsed wall time: %s\n", prettytime(wall_progress))
         msg8 = @sprintf("SYPD: %.2f\n", (callback_iteration_interval * sim.Δt) / step_time / 365)
-        msg9 = @sprintf("advective_cfl: %.2f at lat=%.2f, lon=%.2f, z=%.1f m, dominant=%s\n",
-                        advective_cfl, cfl_latitude, cfl_longitude, cfl_depth, dominant_component)
+        msg9 = @sprintf("advective_cfl: %.2f\n", advective_cfl)
         @info msg1 * msg2 * msg3 * msg4 * msg5 * msg6 * msg7 * msg8 * msg9
         wall_time[] = current_wall_time
         return nothing
     end
 
     add_callback!(simulation, progress, callback_interval)
+    return nothing
+end
+function submit_mediaflux_archive_job!(; output_dir=output_path,
+                                         checkpoint_prefix=default_checkpoint_prefix)
+    if !isfile(mediaflux_archive_submission_script)
+        @warn "Mediaflux archive submission script not found; skipping archive submission" mediaflux_archive_submission_script
+        return nothing
+    end
+
+    required_env_vars = ("MEDIAFLUX_PROJ_PATH",)
+    missing_env_vars = [name for name in required_env_vars if isempty(get(ENV, name, ""))]
+    if !isempty(missing_env_vars)
+        @warn "Mediaflux archive submission skipped because required environment variables are missing" missing_env_vars
+        return nothing
+    end
+
+    export_arg = join((
+        "ALL",
+        "MEDIAFLUX_ARCHIVE_OUTPUT_PATH=$(output_dir)",
+        "MEDIAFLUX_ARCHIVE_CHECKPOINT_PREFIX=$(checkpoint_prefix)"), ",")
+
+    cmd = `sbatch --export=$export_arg $mediaflux_archive_submission_script`
+
+    try
+        @info "Submitting Mediaflux checkpoint archive job" command=string(cmd)
+        run(cmd)
+    catch err
+        @warn "Failed to submit Mediaflux checkpoint archive job" exception=(err, catch_backtrace())
+    end
+
+    return nothing
+end
+
+function add_mediaflux_archive_callback!(simulation;
+                                         archive_interval=default_mediaflux_archive_interval,
+                                         output_dir=output_path,
+                                         checkpoint_prefix=default_checkpoint_prefix)
+    archive_interval <= 0 && return nothing
+    archive_schedule = TimeInterval(archive_interval)
+
+    function submit_archive(sim)
+        @info "Mediaflux archive callback triggered" iteration=Oceananigans.iteration(sim) time=prettytime(sim)
+        submit_mediaflux_archive_job!(; output_dir, checkpoint_prefix)
+        return nothing
+    end
+
+    add_callback!(simulation, submit_archive, archive_schedule)
     return nothing
 end
 
@@ -439,8 +432,6 @@ function add_run_output_writers!(simulation, ocean, grid, run_id)
     @info "Defining run-dependent output writers for run $run_id_leading"
 
     outputs = merge(ocean.model.tracers, ocean.model.velocities)
-    diagnostic_subsurface_outputs = merge(outputs, (; e=ocean.model.tracers.e))
-    diagnostic_surface_level = Nz - 1
     remove_existing_diagnostic_output_files!(run_id_leading)
     surface_height = (; surface_height=ocean.model.free_surface.displacement)
     # Surface flux diagnostics are disabled for the ocean-only run because these
@@ -460,21 +451,21 @@ function add_run_output_writers!(simulation, ocean, grid, run_id)
                                                           array_type=Array{Float32})
     end
 
-    # @time ocean.output_writers[:SSH] = JLD2Writer(ocean.model, surface_height;
-    #                                               dir=output_path,
-    #                                               schedule=output_interval,
-    #                                               filename="global_ssh_fields_sxtdeg_RYF_run" * run_id_leading,
-    #                                               with_halos=false,
-    #                                               overwrite_existing=true,
-    #                                               array_type=Array{Float32})
+    @time ocean.output_writers[:SSH] = JLD2Writer(ocean.model, surface_height;
+                                                  dir=output_path,
+                                                  schedule=output_interval,
+                                                  filename="global_ssh_fields_sxtdeg_RYF_run" * run_id_leading,
+                                                  with_halos=false,
+                                                  overwrite_existing=true,
+                                                  array_type=Array{Float32})
 
-    # @time simulation.output_writers[:surface_fluxes] = JLD2Writer(simulation.model, surface_forcing;
-    #                                                               dir=output_path,
-    #                                                               schedule=output_interval,
-    #                                                               filename="global_surface_fluxes_sxtdeg_RYF_run" * run_id_leading,
-    #                                                               with_halos=false,
-    #                                                               overwrite_existing=true,
-    #                                                               array_type=Array{Float32})
+    @time simulation.output_writers[:surface_fluxes] = JLD2Writer(simulation.model, surface_forcing;
+                                                                  dir=output_path,
+                                                                  schedule=output_interval,
+                                                                  filename="global_surface_fluxes_sxtdeg_RYF_run" * run_id_leading,
+                                                                  with_halos=false,
+                                                                  overwrite_existing=true,
+                                                                  array_type=Array{Float32})
 
     # @time ocean.output_writers[:diagnostic_subsurface] = JLD2Writer(ocean.model, diagnostic_subsurface_outputs;
     #                                                                 dir=output_path,
@@ -495,18 +486,23 @@ function add_run_output_writers!(simulation, ocean, grid, run_id)
     #                                                                   overwrite_existing=true,
     #                                                                   array_type=Array{Float32})
 
-    # @time ocean.output_writers[:integral] = JLD2Writer(ocean.model, build_global_outputs(ocean, grid);
-    #                                                    dir=output_path,
-    #                                                    schedule=output_interval,
-    #                                                    filename="global_tot_integrals_sxtdeg_RYF_run" * run_id_leading,
-    #                                                    overwrite_existing=true)
+    @time ocean.output_writers[:integral] = JLD2Writer(ocean.model, build_global_outputs(ocean, grid);
+                                                       dir=output_path,
+                                                       schedule=output_interval,
+                                                       filename="global_tot_integrals_sxtdeg_RYF_run" * run_id_leading,
+                                                       overwrite_existing=true)
 
     return nothing
 end
 
-function build_simulation(arch, run_id; add_outputs=true, Δt=10minutes)
-    dates = ryf_dates()
-    dataset = EN4Monthly()
+function build_simulation(arch, run_id;
+                          add_outputs=true,
+                          Δt=10minutes,
+                          enable_mediaflux_archive=!isempty(get(ENV, "MEDIAFLUX_PROJ_PATH", "")),
+                          mediaflux_archive_interval=default_mediaflux_archive_interval,
+                          checkpoint_prefix=default_checkpoint_prefix)
+    dates = ecco_dates()
+    dataset = ECCO4Monthly()
     time_indices_in_memory = 24
     inputs = download_input_data!(dates, dataset)
 
@@ -527,7 +523,7 @@ function build_simulation(arch, run_id; add_outputs=true, Δt=10minutes)
     closure = (catke_closure, VerticalScalarDiffusivity(κ=1e-5, ν=1e-4))
 
     @info "Defining free surface"
-    free_surface = SplitExplicitFreeSurface(grid; substeps=70)
+    free_surface = SplitExplicitFreeSurface(grid; substeps=100)
     momentum_advection = WENOVectorInvariant()
     tracer_advection = WENO(order=7)
     sea_ice_advection = WENO(order=7, minimum_buffer_upwind_order=1)
@@ -542,14 +538,12 @@ function build_simulation(arch, run_id; add_outputs=true, Δt=10minutes)
                                    radiative_forcing=nothing,
                                    closure)
 
-    @info "Initialising with EN4"
+    @info "Initialising with ECCO4"
     set!(ocean.model,
          T=Metadata(:temperature; dates=first(dates), dataset, dir=data_path),
          S=Metadata(:salinity; dates=first(dates), dataset, dir=data_path))
 
     @info "Creating sea ice model"
-    # sea_ice_rheology = ElastoViscoPlasticRheology(rheology_activation_concentration = (0.15, 0.80))
-    # sea_ice_dynamics = NumericalEarth.SeaIces.sea_ice_dynamics(grid, ocean; rheology = sea_ice_rheology)
     sea_ice = sea_ice_simulation(grid, ocean;
                                  advection = sea_ice_advection)
 
@@ -564,13 +558,16 @@ function build_simulation(arch, run_id; add_outputs=true, Δt=10minutes)
     land = JRA55PrescribedLand(arch; time_indices_in_memory)
 
     @info "Defining coupled model"
-    # interfaces = ComponentInterfaces(atmosphere, ocean, sea_ice; radiation, sea_ice_ocean_salinity_flux = nothing)
-    # @time coupled_model = OceanSeaIceModel(sea_ice, ocean; atmosphere, radiation, interfaces)
     @time coupled_model = OceanSeaIceModel(sea_ice, ocean; atmosphere, radiation)
-    # @time coupled_model = OceanOnlyModel(ocean; atmosphere, land, radiation)
 
     simulation = Simulation(coupled_model; Δt)
     add_progress_callback!(simulation)
+    if enable_mediaflux_archive
+        add_mediaflux_archive_callback!(simulation;
+                                        archive_interval=mediaflux_archive_interval,
+                                        output_dir=output_path,
+                                        checkpoint_prefix=checkpoint_prefix)
+    end
 
     if add_outputs
         add_run_output_writers!(simulation, ocean, grid, run_id)
@@ -579,7 +576,7 @@ function build_simulation(arch, run_id; add_outputs=true, Δt=10minutes)
     @time simulation.output_writers[:checkpointer] = Checkpointer(coupled_model,
                                                                   schedule=checkpoint_interval,
                                                                   dir=output_path,
-                                                                  prefix="RYF_sxtdeg_checkpoint_artefact",
+                                                                  prefix=checkpoint_prefix,
                                                                   overwrite_existing=true,
                                                                   cleanup=false)
 

--- a/experiments/submission_scripts/mediaflux_archive_checkpoints.jl
+++ b/experiments/submission_scripts/mediaflux_archive_checkpoints.jl
@@ -1,0 +1,166 @@
+const DEFAULT_CHECKPOINT_PREFIX = "RYF_sxtdeg_checkpoint"
+const DEFAULT_OUTPUT_PATH = normpath(joinpath(@__DIR__, "..", "..", "outputs"))
+const DEFAULT_MEDIAFLUX_CONFIG = expanduser("~/.Arcitecta/mflux.cfg")
+const DEFAULT_MEDIAFLUX_DEST_SUFFIX = ("ocean-ensembles", "outputs")
+const DEFAULT_MEDIAFLUX_UPLOAD_CMD = "unimelb-mf-upload"
+const DEFAULT_MEDIAFLUX_WORKERS = 4
+const MANIFEST_NAME = ".mediaflux_archived_checkpoints.log"
+const LOCKDIR_NAME = ".mediaflux_archive.lock"
+
+required_env(name) = get(ENV, name, "") == "" ? throw(ArgumentError("Environment variable $name must be set")) : ENV[name]
+
+function checkpoint_iteration(filename)
+    match_data = match(r"_iteration(\d+)\.jld2$", basename(filename))
+    isnothing(match_data) && return nothing
+    return parse(Int, match_data.captures[1])
+end
+
+function checkpoint_files(output_dir, checkpoint_prefix)
+    prefix = checkpoint_prefix * "_iteration"
+    files = String[]
+
+    for name in readdir(output_dir)
+        path = joinpath(output_dir, name)
+        if !isfile(path)
+            continue
+        elseif !startswith(name, prefix) || !endswith(name, ".jld2")
+            continue
+        elseif isnothing(checkpoint_iteration(name))
+            continue
+        end
+
+        push!(files, path)
+    end
+
+    sort!(files; by=path -> checkpoint_iteration(path))
+    return files
+end
+
+function read_manifest(manifest_path)
+    if !isfile(manifest_path)
+        return Set{String}()
+    end
+
+    archived = Set{String}()
+    for line in eachline(manifest_path)
+        entry = strip(line)
+        isempty(entry) || push!(archived, entry)
+    end
+
+    return archived
+end
+
+function append_manifest!(manifest_path, files)
+    isempty(files) && return nothing
+    open(manifest_path, "a") do io
+        for file in files
+            println(io, basename(file))
+        end
+    end
+    return nothing
+end
+
+function join_mediaflux_path(parts::AbstractString...)
+    cleaned = String[]
+    for part in parts
+        stripped = strip(part, '/')
+        isempty(stripped) || push!(cleaned, stripped)
+    end
+    return join(cleaned, "/")
+end
+
+function upload_files!(files; mf_config, remote_project_path)
+    isempty(files) && return nothing
+
+    upload_cmd = get(ENV, "MEDIAFLUX_UPLOAD_CMD", DEFAULT_MEDIAFLUX_UPLOAD_CMD)
+    nb_workers = parse(Int, get(ENV, "MEDIAFLUX_NB_WORKERS", string(DEFAULT_MEDIAFLUX_WORKERS)))
+    destination = join_mediaflux_path(remote_project_path, DEFAULT_MEDIAFLUX_DEST_SUFFIX...)
+
+    cmd = Cmd([
+        upload_cmd,
+        "--mf.config", mf_config,
+        "--dest", destination,
+        "--create-parents",
+        "--nb-workers", string(nb_workers),
+        "--preserve-modified-time",
+        files...,
+    ])
+
+    @info "Uploading checkpoint files to Mediaflux" destination count=length(files) nb_workers
+    run(cmd)
+    return nothing
+end
+
+function delete_files!(files)
+    isempty(files) && return nothing
+
+    for file in files
+        if isfile(file)
+            @info "Deleting archived checkpoint file" file
+            rm(file; force=true)
+        end
+    end
+
+    return nothing
+end
+
+function main()
+    remote_project_path = required_env("MEDIAFLUX_PROJ_PATH")
+    mf_config = expanduser(get(ENV, "MEDIAFLUX_MF_CONFIG", DEFAULT_MEDIAFLUX_CONFIG))
+    output_dir = expanduser(get(ENV, "MEDIAFLUX_ARCHIVE_OUTPUT_PATH", DEFAULT_OUTPUT_PATH))
+    checkpoint_prefix = get(ENV, "MEDIAFLUX_ARCHIVE_CHECKPOINT_PREFIX", DEFAULT_CHECKPOINT_PREFIX)
+
+    isdir(output_dir) || throw(ArgumentError("Output directory does not exist: $output_dir"))
+    isfile(mf_config) || throw(ArgumentError("Mediaflux config does not exist: $mf_config"))
+
+    manifest_path = joinpath(output_dir, MANIFEST_NAME)
+    lockdir_path = joinpath(output_dir, LOCKDIR_NAME)
+
+    try
+        mkdir(lockdir_path)
+    catch err
+        if err isa Base.IOError || err isa SystemError
+            @warn "Another Mediaflux archive job appears to be active; skipping this run" lockdir_path
+            return nothing
+        end
+        rethrow(err)
+    end
+
+    try
+        files = checkpoint_files(output_dir, checkpoint_prefix)
+        if length(files) <= 1
+            @info "Nothing to archive yet; keeping the most recent checkpoint locally" count=length(files)
+            return nothing
+        end
+
+        archived = read_manifest(manifest_path)
+        latest_file = last(files)
+        older_files = files[1:end-1]
+
+        already_uploaded = [file for file in older_files if basename(file) in archived]
+        pending_upload = [file for file in older_files if !(basename(file) in archived)]
+
+        if isempty(already_uploaded) && isempty(pending_upload)
+            @info "No checkpoint files are eligible for archiving"
+            return nothing
+        end
+
+        if !isempty(pending_upload)
+            upload_files!(pending_upload;
+                          mf_config,
+                          remote_project_path)
+            append_manifest!(manifest_path, pending_upload)
+        end
+
+        deletable_files = vcat(already_uploaded, pending_upload)
+        delete_files!(deletable_files)
+
+        @info "Mediaflux checkpoint archive completed" latest_checkpoint=basename(latest_file) uploaded=length(pending_upload) deleted=length(deletable_files)
+    finally
+        isdir(lockdir_path) && rm(lockdir_path; force=true, recursive=true)
+    end
+
+    return nothing
+end
+
+main()

--- a/experiments/submission_scripts/mediaflux_archive_checkpoints.sh
+++ b/experiments/submission_scripts/mediaflux_archive_checkpoints.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --mem=8G
+#SBATCH --time=24:00:00
+#SBATCH --job-name=mediaflux_ckpt
+#SBATCH --output=../run_logs/mediaflux_ckpt_%j.out
+#SBATCH --error=../run_logs/mediaflux_ckpt_%j.err
+#SBATCH --export=ALL
+
+set -euo pipefail
+
+if [ -f "${HOME}/.bashrc" ]; then
+  source "${HOME}/.bashrc"
+fi
+
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd "${script_dir}/../.." && pwd)"
+
+cd "${repo_root}"
+
+julia --project="${repo_root}/experiments/submission_scripts" \
+  "${repo_root}/experiments/submission_scripts/mediaflux_archive_checkpoints.jl"

--- a/outputs/delete_old_files
+++ b/outputs/delete_old_files
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat <<EOF
+Usage:
+  ./delete_old_files --date DD-MM-YYYY [--time HH:MM:SS] [--dry-run]
+
+Deletes regular files in this outputs directory, recursively, whose modification
+time is on or before DD-MM-YYYY HH:MM:SS in local time. If --time is omitted,
+it defaults to 23:59:59, deleting all files modified on or before DD-MM-YYYY.
+The script itself is never deleted.
+
+Examples:
+  ./delete_old_files --date 12-05-2026
+  ./delete_old_files --date 12-05-2026 --time 21:18:00
+  ./delete_old_files --date 12-05-2026 --dry-run
+EOF
+}
+
+script_dir="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+script_path="$script_dir/$(basename -- "${BASH_SOURCE[0]}")"
+date_arg=""
+time_arg="23:59:59"
+dry_run=false
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --date)
+            [[ $# -ge 2 ]] || { echo "error: --date requires DD-MM-YYYY" >&2; exit 2; }
+            date_arg="$2"
+            shift 2
+            ;;
+        --time)
+            [[ $# -ge 2 ]] || { echo "error: --time requires HH:MM:SS" >&2; exit 2; }
+            time_arg="$2"
+            shift 2
+            ;;
+        --dry-run)
+            dry_run=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            echo "error: unknown argument: $1" >&2
+            usage >&2
+            exit 2
+            ;;
+    esac
+done
+
+[[ -n "$date_arg" ]] || { echo "error: missing --date DD-MM-YYYY" >&2; usage >&2; exit 2; }
+
+if [[ ! "$date_arg" =~ ^([0-9]{2})-([0-9]{2})-([0-9]{4})$ ]]; then
+    echo "error: date must be DD-MM-YYYY, for example 12-05-2026" >&2
+    exit 2
+fi
+
+day="${BASH_REMATCH[1]}"
+month="${BASH_REMATCH[2]}"
+year="${BASH_REMATCH[3]}"
+cutoff_iso="$year-$month-$day"
+
+if [[ ! "$time_arg" =~ ^([0-9]{2}):([0-9]{2}):([0-9]{2})$ ]]; then
+    echo "error: time must be HH:MM:SS, for example 21:18:00" >&2
+    exit 2
+fi
+
+cutoff_timestamp="$cutoff_iso $time_arg"
+
+validated="$(date -d "$cutoff_iso" +%Y-%m-%d 2>/dev/null)" || {
+    echo "error: invalid date: $date_arg" >&2
+    exit 2
+}
+
+if [[ "$validated" != "$cutoff_iso" ]]; then
+    echo "error: invalid date: $date_arg" >&2
+    exit 2
+fi
+
+validated_time="$(date -d "$cutoff_timestamp" +%H:%M:%S 2>/dev/null)" || {
+    echo "error: invalid time: $time_arg" >&2
+    exit 2
+}
+
+if [[ "$validated_time" != "$time_arg" ]]; then
+    echo "error: invalid time: $time_arg" >&2
+    exit 2
+fi
+
+if $dry_run; then
+    echo "Would delete files in $script_dir modified on or before $date_arg $time_arg local time:"
+    find "$script_dir" \
+        -type f \
+        ! -samefile "$script_path" \
+        ! -newermt "$cutoff_timestamp" \
+        -print
+else
+    echo "Deleting files in $script_dir modified on or before $date_arg $time_arg local time..."
+    find "$script_dir" \
+        -type f \
+        ! -samefile "$script_path" \
+        ! -newermt "$cutoff_timestamp" \
+        -print \
+        -delete
+fi


### PR DESCRIPTION
## Summary
Add lightweight runtime diagnostics around the split-explicit free-surface setup in `RYF_sxtdeg_serial.jl`, while also aligning callback scheduling and archive cadence with the long-running serial experiment configuration.

## Problem
The serial RYF configuration did not expose whether the configured free-surface substepping was below the recommended value for the chosen `Δt`, which made halo-fold instability diagnosis harder. The progress callback was also still wired through a time-based interval even though the current configuration is expressed in iterations.

## Fix
Switch the progress callback to an iteration-based schedule, reduce the configured free-surface substeps from 100 to 70, and add a pre-run check that compares the actual substeps against the recommended value from `SplitExplicitFreeSurface(...; cfl=0.8, fixed_Δt=Δt)`. If the configured value is too low, the run now logs an explicit warning before stepping forward. This also stretches checkpoint archive submission to yearly cadence so the diagnostic run does not submit archive jobs every few days.

## Scripts fixed
- `experiments/RYF_sxtdeg_serial.jl`

## Changes in each script
- `experiments/RYF_sxtdeg_serial.jl`: change `callback_iteration_interval` from a `TimeInterval(10days)`-style setting to `720` iterations and schedule the progress callback with `IterationInterval`.
- `experiments/RYF_sxtdeg_serial.jl`: change `default_mediaflux_archive_interval` from `6days` to `365days`.
- `experiments/RYF_sxtdeg_serial.jl`: reduce `SplitExplicitFreeSurface` substeps from `100` to `70`.
- `experiments/RYF_sxtdeg_serial.jl`: add a runtime diagnostic in `run_segment!` that computes the recommended free-surface substeps and warns when the configured value is smaller.

## Validation
Not run locally per repository instructions; validation will come from GitHub-managed checks.
